### PR TITLE
Fixing the go1.3 compatibility issue

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
+//	"time"
 )
 
 // LogLevel is used to control what is written to the log.

--- a/conn.go
+++ b/conn.go
@@ -314,7 +314,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	if params.TimeoutSeconds <= 0 {
 		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {
-		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Second)))
+		panicIfErr(tcpConn.SetDeadline(time.Now().Add(time.Duration(params.TimeoutSeconds)*time.Second)))
 	}
 	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 

--- a/conn.go
+++ b/conn.go
@@ -309,11 +309,11 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 
-	log.Printf("TimeoutSeconds: %d", TimeoutSeconds)
-	if TimeoutSeconds <= 0 {
+	log.Printf("TimeoutSeconds: %d", params.TimeoutSeconds)
+	if params.TimeoutSeconds <= 0 {
 		panicIfErr(tcpConn.SetDeadline(0))
 	} else {
-		panicIfErr(tcpConn.SetDeadline(time.Now().Add(TimeoutSeconds*time.Seconds)))
+		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds)))
 	}
 	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 

--- a/conn.go
+++ b/conn.go
@@ -304,7 +304,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	newConn.logf(LogPanic, "", "FIRST LOG")
+	newConn.log(LogPanic, "FIRST LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 

--- a/conn.go
+++ b/conn.go
@@ -310,8 +310,9 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	panicIfErr(err)
 
 	log.Printf("TimeoutSeconds: %d", params.TimeoutSeconds)
+	var noDeadline = time.Time{}
 	if params.TimeoutSeconds <= 0 {
-		panicIfErr(tcpConn.SetDeadline(net.noDeadline))
+		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {
 		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds)))
 	}

--- a/conn.go
+++ b/conn.go
@@ -311,7 +311,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 
 	log.Printf("TimeoutSeconds: %d", params.TimeoutSeconds)
 	if params.TimeoutSeconds <= 0 {
-		panicIfErr(tcpConn.SetDeadline(0))
+		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {
 		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds)))
 	}

--- a/conn.go
+++ b/conn.go
@@ -305,7 +305,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	log.Print("FIRST LOG")
+	log.Print("1st LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 
@@ -323,8 +323,10 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		newConn.onErrorDontRequireReadyForQuery = false
 	}()
 
+	log.Print("2nd LOG")
 	newConn.writeStartup()
 
+	log.Print("3rd LOG")
 	newConn.readBackendMessages(nil)
 
 	newConn.state = readyState{}

--- a/conn.go
+++ b/conn.go
@@ -332,6 +332,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	newConn.transactionStatus = NotInTransaction
 
 	conn = newConn
+	conn.log(LogPanic, "FIRST LOG")
 
 	return
 }

--- a/conn.go
+++ b/conn.go
@@ -338,7 +338,6 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	newConn.transactionStatus = NotInTransaction
 
 	conn = newConn
-	//conn.log(LogPanic, "FIRST LOG")
 
 	return
 }

--- a/conn.go
+++ b/conn.go
@@ -309,6 +309,12 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 
+	log.Printf("TimeoutSeconds: %d", TimeoutSeconds)
+	if TimeoutSeconds <= 0 {
+		panicIfErr(tcpConn.SetDeadline(0))
+	} else {
+		panicIfErr(tcpConn.SetDeadline(time.Now().Add(TimeoutSeconds*time.Seconds)))
+	}
 	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 
 	newConn.tcpConn = tcpConn

--- a/conn.go
+++ b/conn.go
@@ -305,18 +305,17 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	log.Print("1st LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 
-	log.Printf("TimeoutSeconds: %d", params.TimeoutSeconds)
+	// Handling the timeout using SetDeadline and an absolute date
+	// 0 if no timeout
 	noDeadline := time.Time{}
 	if params.TimeoutSeconds <= 0 {
 		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {
 		panicIfErr(tcpConn.SetDeadline(time.Now().Add(time.Duration(params.TimeoutSeconds)*time.Second)))
 	}
-	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 
 	newConn.tcpConn = tcpConn
 
@@ -330,10 +329,8 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		newConn.onErrorDontRequireReadyForQuery = false
 	}()
 
-	log.Print("2nd LOG")
 	newConn.writeStartup()
 
-	log.Print("3rd LOG")
 	newConn.readBackendMessages(nil)
 
 	newConn.state = readyState{}

--- a/conn.go
+++ b/conn.go
@@ -304,7 +304,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	newConn.log(newConn.LogDebug, "FIRST LOG")
+	newConn.log(LogPanic, "FIRST LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 

--- a/conn.go
+++ b/conn.go
@@ -304,7 +304,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	newConn.log(LogPanic, "FIRST LOG")
+	//newConn.log(LogPanic, "FIRST LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 
@@ -332,7 +332,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	newConn.transactionStatus = NotInTransaction
 
 	conn = newConn
-	conn.log(LogPanic, "FIRST LOG")
+	//conn.log(LogPanic, "FIRST LOG")
 
 	return
 }

--- a/conn.go
+++ b/conn.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strconv"

--- a/conn.go
+++ b/conn.go
@@ -314,7 +314,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	if params.TimeoutSeconds <= 0 {
 		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {
-		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds())))
+		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Second)))
 	}
 	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 

--- a/conn.go
+++ b/conn.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"strconv"
@@ -304,7 +305,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	//newConn.log(LogPanic, "FIRST LOG")
+	log.Print("FIRST LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 

--- a/conn.go
+++ b/conn.go
@@ -304,7 +304,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
-	newConn.log(LogPanic, "FIRST LOG")
+	newConn.log(newConn.LogDebug, "FIRST LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 

--- a/conn.go
+++ b/conn.go
@@ -310,7 +310,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	panicIfErr(err)
 
 	log.Printf("TimeoutSeconds: %d", params.TimeoutSeconds)
-	var noDeadline = time.Time{}
+	noDeadline := time.Time{}
 	if params.TimeoutSeconds <= 0 {
 		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {

--- a/conn.go
+++ b/conn.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
-//	"time"
+	"time"
 )
 
 // LogLevel is used to control what is written to the log.

--- a/conn.go
+++ b/conn.go
@@ -304,6 +304,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 		params.User = env
 	}
 
+	newConn.logf(LogPanic, "", "FIRST LOG")
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 

--- a/conn.go
+++ b/conn.go
@@ -314,7 +314,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	if params.TimeoutSeconds <= 0 {
 		panicIfErr(tcpConn.SetDeadline(noDeadline))
 	} else {
-		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds)))
+		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds())))
 	}
 	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 

--- a/conn.go
+++ b/conn.go
@@ -311,7 +311,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 
 	log.Printf("TimeoutSeconds: %d", params.TimeoutSeconds)
 	if params.TimeoutSeconds <= 0 {
-		panicIfErr(tcpConn.SetDeadline(noDeadline))
+		panicIfErr(tcpConn.SetDeadline(net.noDeadline))
 	} else {
 		panicIfErr(tcpConn.SetDeadline(time.Now().Add(params.TimeoutSeconds*time.Seconds)))
 	}

--- a/conn.go
+++ b/conn.go
@@ -309,7 +309,7 @@ func Connect(connStr string, logLevel LogLevel) (conn *Conn, err error) {
 	tcpConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", params.Host, params.Port))
 	panicIfErr(err)
 
-	panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
+	//panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
 
 	newConn.tcpConn = tcpConn
 

--- a/conn_write.go
+++ b/conn_write.go
@@ -307,6 +307,7 @@ func (conn *Conn) writeQuery(command string) {
 }
 
 func (conn *Conn) writeStartup() {
+	conn.log(LogDebug, "Inside writeStartup")
 	if conn.LogLevel >= LogDebug {
 		defer conn.logExit(conn.logEnter("*Conn.writeStartup"))
 	}

--- a/conn_write.go
+++ b/conn_write.go
@@ -307,7 +307,6 @@ func (conn *Conn) writeQuery(command string) {
 }
 
 func (conn *Conn) writeStartup() {
-	conn.log(LogDebug, "Inside writeStartup")
 	if conn.LogLevel >= LogDebug {
 		defer conn.logExit(conn.logEnter("*Conn.writeStartup"))
 	}


### PR DESCRIPTION
After investigation this is due to the deadline set using the following line:

```
panicIfErr(tcpConn.SetDeadline(time.Unix(int64(params.TimeoutSeconds*1000*1000*1000), 0)))
```

Line located within conn.go into the Connect proc. I guess this line is an attempt to use the timeout parameter provided by the caller and to **add** it to Time.Now() in order to stop dialling after the amount of seconds specified as a parameter.

I am just wondering why it has worked before unless the meaning of the SetDeadline procedure has completely been modified.

This pull request is how I would fix it. Now you can obviously decide to fix it differently.
